### PR TITLE
Added .verifySource() method to PASAccount

### DIFF
--- a/Classes/PASAccount.ps1
+++ b/Classes/PASAccount.ps1
@@ -240,6 +240,35 @@ class PASAccount
         }
     }# VerifyPassword()
 
+	[System.Boolean] VerifySource()
+	{
+		$result = $null
+		
+		switch ($this.SourceType) {
+			"Host" { 
+				$result = Invoke-PASAPI -APICall ServerManage/CheckTargetHealth -Body ( @{ID=$this.SourceId ; TargetType="Computer"} | ConvertTo-Json )	
+				break;
+			}
+			"Database" {
+				$result = Invoke-PASAPI -APICall ServerManage/CheckTargetHealth -Body ( @{ID=$this.SourceId ; TargetType="Database"} | ConvertTo-Json )
+				break;
+			}
+			
+		}# switch ($this.SourceType)
+
+		$this.Healthy = $result
+		
+		# if the VerifySource comes back okay, return true
+		if ($result -eq "OK")
+		{ 
+			return $true
+		} 
+		else 
+		{
+			return $false
+		}# if ($result -eq "OK")
+	}# VerifySource()
+
     [System.Boolean] UpdatePassword($password)
     {
         # if the account was successfully managed


### PR DESCRIPTION
Pretty straight-forward change. Adding a method to allow us to re-check the status of the Source for an individual account. 

I see some issues when working with multiple accounts specifically, if I run `.verifySource()` on `$account[0]` and `$account[1]` has the same Source, it won't update `$account[1]` until `.verifySource()` is run. This could make the creation of a `PASSystem` object helpful.